### PR TITLE
1.2.0

### DIFF
--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -12,69 +12,68 @@ struct ContentView: View {
     @EnvironmentObject private var globalAlert: GlobalAlert
 
     var body: some View {
-        VStack {
-            Group {
-                Button("Show simple alert") {
-                    globalAlert.showAlert(
-                        "Success!",
-                        message: "The operation was completed!"
-                    )
-                }
-
-                Button("Show alert with action") {
-                    globalAlert.showAlert(
-                        "Confirmation",
-                        message: "Proceed with this action?",
-                        buttons: [
-                            .init("Cancel", role: .cancel),
-                            .init("OK") {
-                                print("Action confirmed! 👍")
-                            }
-                        ]
-                    )
-                }
-
-                Button("Show three-button alert") {
-                    globalAlert.showAlert(
-                        "Delete Data?",
-                        message: "This action cannot be undone.",
-                        buttons: [
-                            .init(
-                                "Delete",
-                                role: .destructive
-                            ),
-                            .init(
-                                "View Details"
-                            ),
-                            .init(
-                                "Cancel",
-                                role: .cancel
-                            ),
-                        ]
-                    )
-                }
-
-                Button("Show confirmation alert") {
-                    globalAlert.showConfirmationDialog(
-                        "Overwrite File?",
-                        message: "A file with the same name exists. Overwrite?",
-                        buttons: [
-                            .init(
-                                "Overwrite",
-                                role: .destructive
-                            ),
-                            .init(
-                                "Save As"
-                            ),
-                            .init(
-                                "Cancel",
-                                role: .cancel
-                            ),
-                        ]
-                    )
-                }
+        VStack(spacing: 24) {
+            Button("Show simple alert") {
+                globalAlert.showAlert(
+                    "Success!",
+                    message: "The operation was completed!"
+                )
             }
-            .padding()
+
+            Button("Show alert with action") {
+                globalAlert.showAlert(
+                    "Confirmation",
+                    message: "Proceed with this action?",
+                    buttons: [
+                        .init("Cancel", role: .cancel),
+                        .init("OK") {
+                            print("Action confirmed! 👍")
+                        }
+                    ]
+                )
+            }
+
+            Button("Show three-button alert") {
+                globalAlert.showAlert(
+                    "Delete Data?",
+                    message: "This action cannot be undone.",
+                    buttons: [
+                        .init(
+                            "Delete",
+                            role: .destructive
+                        ),
+                        .init(
+                            "View Details"
+                        ),
+                        .init(
+                            "Cancel",
+                            role: .cancel
+                        ),
+                    ]
+                )
+            }
+
+            Button("Show confirmation alert") {
+                globalAlert.showConfirmationDialog(
+                    "Overwrite File?",
+                    message: "A file with the same name exists. Overwrite?",
+                    buttons: [
+                        .init(
+                            "Overwrite",
+                            role: .destructive
+                        ),
+                        .init(
+                            "Save As"
+                        ),
+                        .init(
+                            "Cancel",
+                            role: .cancel
+                        ),
+                    ]
+                )
+            }
+
+            Spacer()
         }
     }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2025 NIWA Yuichiro
+Copyright 2025-2026 NIWA Yuichiro
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ struct ContentView: View {
 ```
 
 <p align="center">
-    <img src="https://github.com/user-attachments/assets/9f10694f-b638-4261-b79c-36d1deddbdd4" width="400"/>
+    <img width="400" alt="Alert with a button" src="https://github.com/user-attachments/assets/358e1246-ad01-43ad-bc8c-772041f11490" />
 </p>
 
 ## 📦 Installation
@@ -78,7 +78,7 @@ globalAlert.showAlert(
 ```
 
 <p align="center">
-    <img src="https://github.com/user-attachments/assets/81f60c21-6e62-4999-84b4-1d25a9ff64c4" width="400"/>
+    <img width="400" alt="Alert with two buttons" src="https://github.com/user-attachments/assets/929724fa-8909-4656-a626-5269235b204b" />
 </p>
 
 #### Three-Button Alert
@@ -104,10 +104,10 @@ globalAlert.showAlert(
 ```
 
 <p align="center">
-    <img src="https://github.com/user-attachments/assets/c2457622-a018-4ec8-b130-8218ed13bee5" width="400"/>
+    <img width="400" alt="Alert with three buttons" src="https://github.com/user-attachments/assets/25a0cf00-9fc7-4af6-85fb-6461d4bcab2b" />
 </p>
 
-### 📢 Using confirmationDialog
+### 📢 Using confirmationDialog (Deprecated in iOS 26)
 
 You can also display a confirmation dialog:
 
@@ -132,5 +132,5 @@ globalAlert.showConfirmationDialog(
 ```
 
 <p align="center">
-    <img src="https://github.com/user-attachments/assets/eef6b586-7000-4349-ae8d-4b1a4081fbc9" width="400"/>
+    <img width="400" alt="Confirmation Dialog" src="https://github.com/user-attachments/assets/73373cb8-0f03-401a-b50c-2cbca69efec8" />
 </p>

--- a/Sources/GlobalAlert/GlobalAlert.swift
+++ b/Sources/GlobalAlert/GlobalAlert.swift
@@ -18,6 +18,7 @@ public final class GlobalAlert: ObservableObject {
         isShowAlert = true
     }
 
+    @available(iOS, introduced: 15.0, deprecated: 26.0, message: "Use genuine confirmationDialog instead")
     @MainActor
     public func showConfirmationDialog(
         _ titleKey: LocalizedStringKey,
@@ -53,6 +54,7 @@ extension GlobalAlert {
         showAlert(titleKey, message: nil, buttons: [])
     }
 
+    @available(iOS, introduced: 15.0, deprecated: 26.0, message: "Use genuine confirmationDialog instead")
     @MainActor
     public func showConfirmationDialog(
         _ titleKey: LocalizedStringKey,


### PR DESCRIPTION
## GlobalAlert 1.2.0
- Updated the swift tools version from `5.9` to `6.2`.
- The `showConfirmationDialog` method of the `GlobalAlert` class has been deprecated due to display rendering issues.

    <img width="200" alt="confirmation-dialog-on-ios-26" src="https://github.com/user-attachments/assets/de0cbb32-77ca-4757-92bc-d7ced5c98e64" />

- Updated the `README.md` image to the iOS 26 version.
- Adjusted the layout of the demo app.